### PR TITLE
Keep container user as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,13 @@ RUN adduser --disabled-password --gecos '' user && \
 	mkdir -p /content/app /content/data
 
 COPY entrypoint.sh /content/
-RUN chown -R user:user /content
+# RUN chown -R user:user /content
 
 WORKDIR /content
-USER user
+# USER user
 
-COPY --chown=user:user . /content/app
+# COPY --chown=user:user . /content/app
+COPY . /content/app
 RUN mv /content/app/models /content/app/models.org
 
 CMD [ "sh", "-c", "/content/entrypoint.sh ${CMDARGS}" ]


### PR DESCRIPTION
This pull request includes changes to the `Dockerfile` to remove the creation of a `user` and keep using `root`. Since this job writes to the volumes, we may face some issues with write permissions. Keeping the root user seems to fix that

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L21-R27): Commented out the `chown` and `USER` commands, and modified the `COPY` command to not include ownership changes.